### PR TITLE
Update .htaccess for missing assets & uploads

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -5,11 +5,17 @@
         RewriteBase /
     </IfModule>
 
-    # Redirect Trailing Slashes If Not A Folder...
+    # Handle missing assets and stored media
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_URI} ^/?(assets|uploads)(/.+)? [NC]
+    RewriteRule ^ - [QSA,L,R=404]
+
+    # Redirect trailing slashes if not a folder…
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)/$ /$1 [L,R=301]
 
-    # Handle Front Controller...
+    # Handle front controller…
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [QSA,L]
 </IfModule>


### PR DESCRIPTION
If assets or uploaded resources are missing, respond with a simple _400 Bad Request_ instead of passing the URI to the application to build an error page.

Normally, missing files return _404 Not Found_ and missing directories return _403 Forbidden_.

By returning _400_ you discourage prodding of the server for different HTTP status codes.

With `ErrorDocument`, we can provided simple documents with some styles.